### PR TITLE
Change type annotation of `ApplicationModule._handlers`

### DIFF
--- a/lato/application_module.py
+++ b/lato/application_module.py
@@ -17,7 +17,9 @@ class ApplicationModule:
         :param name: Name of the module
         """
         self.name: str = name
-        self._handlers: defaultdict[str, OrderedSet[Callable]] = defaultdict(OrderedSet)
+        self._handlers: defaultdict[HandlerAlias, OrderedSet[Callable]] = defaultdict(
+            OrderedSet
+        )
         self._submodules: OrderedSet[ApplicationModule] = OrderedSet()
 
     @property


### PR DESCRIPTION
It's possible to bind handler function not only to a string, but also to a subclass of `Message` type. Therefore, I think it makes more sense to use `defaultdict[HandlerAlias, OrderedSet[Callable]]` annotation instead of `defaultdict[str, OrderedSet[Callable]]`.