### PR TITLE
Fix type annotations in `ApplicationModule` class

### DIFF
--- a/lato/application_module.py
+++ b/lato/application_module.py
@@ -17,7 +17,9 @@ class ApplicationModule:
         :param name: Name of the module
         """
         self.name: str = name
-        self._handlers: defaultdict[str, OrderedSet[Callable]] = defaultdict(OrderedSet)
+        self._handlers: defaultdict[HandlerAlias, OrderedSet[Callable]] = defaultdict(
+            OrderedSet
+        )
         self._submodules: OrderedSet[ApplicationModule] = OrderedSet()
 
     @property

--- a/lato/application_module.py
+++ b/lato/application_module.py
@@ -36,7 +36,7 @@ class ApplicationModule:
         ), f"Can only include {ApplicationModule} instances, got {a_module}"
         self._submodules.add(a_module)
 
-    def handler(self, alias: HandlerAlias):
+    def handler(self, alias: HandlerAlias) -> Callable:
         """
         Decorator for registering a handler. Handler can be aliased by a name or by a message type.
 


### PR DESCRIPTION
Hi!

First of all, I wanted to say that's a great job you've done. The framework is awesome!

There were two problems related to `ApplicationModule` which my linter was annoyingly complaining about.

First, internal mapping of handlers (`ApplicationModule._handlers`) were annotated to have a type `str` as a key, while it's actully possible to use both `str` and `type[Message]` (`HandlerAlias`).

Second, the linter couldn't understand that the return type of `ApplicationModule.handler` method is always a callable, so I added a return type annotation.